### PR TITLE
Run command

### DIFF
--- a/abmwrappers/utils.py
+++ b/abmwrappers/utils.py
@@ -13,7 +13,8 @@ from cfa_azure.clients import AzureClient
 from scipy.stats import truncnorm
 from scipy.stats.qmc import Sobol
 
-def run_model_command_line(cmd: list, model_type:str, recompile=False):
+
+def run_model_command_line(cmd: list, model_type: str, recompile=False):
     if model_type == "gcm":
         if recompile:
             subprocess.run(["mvn", "clean", "package"], check=True)
@@ -31,24 +32,46 @@ def run_model_command_line(cmd: list, model_type:str, recompile=False):
             stderr=subprocess.DEVNULL,
         )
     else:
-        raise ValueError(f"Unsupported model type: {model_type}. must be 'gcm' or 'ixa'")
+        raise ValueError(
+            f"Unsupported model type: {model_type}. must be 'gcm' or 'ixa'"
+        )
+
 
 def write_default_cmd(
-        simulation_dir: str,
-        model_type: str,
-        exe_file: str,
-        ):
+    simulation_dir: str,
+    model_type: str,
+    exe_file: str,
+):
     output_dir = os.path.join(simulation_dir, "output")
     if model_type == "gcm":
         input_file = os.path.join(simulation_dir, f"input.yaml")
-        cmd = ["java", "-jar", exe_file, "-i", input_file, "-o", output_dir, "-t", "4"]
+        cmd = [
+            "java",
+            "-jar",
+            exe_file,
+            "-i",
+            input_file,
+            "-o",
+            output_dir,
+            "-t",
+            "4",
+        ]
     elif model_type == "ixa":
         input_file = os.path.join(simulation_dir, f"input.json")
-        cmd = [f"./{exe_file}", "--config", f"./{input_file}", "--prefix", f"{output_dir}/"]
+        cmd = [
+            f"./{exe_file}",
+            "--config",
+            f"./{input_file}",
+            "--prefix",
+            f"{output_dir}/",
+        ]
     else:
-        raise ValueError(f"Unsupported model type: {model_type}. must be 'gcm' or 'ixa'")
+        raise ValueError(
+            f"Unsupported model type: {model_type}. must be 'gcm' or 'ixa'"
+        )
 
     return cmd
+
 
 def parameters_writer(params: dict, output_type: str = "YAML") -> str:
     """

--- a/abmwrappers/utils.py
+++ b/abmwrappers/utils.py
@@ -44,7 +44,7 @@ def write_default_cmd(
 ):
     output_dir = os.path.join(simulation_dir, "output")
     if model_type == "gcm":
-        input_file = os.path.join(simulation_dir, f"input.yaml")
+        input_file = os.path.join(simulation_dir, "input.yaml")
         cmd = [
             "java",
             "-jar",
@@ -57,7 +57,7 @@ def write_default_cmd(
             "4",
         ]
     elif model_type == "ixa":
-        input_file = os.path.join(simulation_dir, f"input.json")
+        input_file = os.path.join(simulation_dir, "input.json")
         cmd = [
             f"./{exe_file}",
             "--config",

--- a/abmwrappers/utils.py
+++ b/abmwrappers/utils.py
@@ -13,43 +13,42 @@ from cfa_azure.clients import AzureClient
 from scipy.stats import truncnorm
 from scipy.stats.qmc import Sobol
 
+def run_model_command_line(cmd: list, model_type:str, recompile=False):
+    if model_type == "gcm":
+        if recompile:
+            subprocess.run(["mvn", "clean", "package"], check=True)
+        subprocess.run(
+            cmd,
+            check=True,
+        )
+    elif model_type == "ixa":
+        if recompile:
+            subprocess.run(["cargo", "build", "--release"], check=True)
+        subprocess.run(
+            cmd,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    else:
+        raise ValueError(f"Unsupported model type: {model_type}. must be 'gcm' or 'ixa'")
 
-def run_gcm_command_line(
-    jar_file,
-    yaml_file="./input/config.yaml",
-    output_dir="output",
-    gcm_threads=4,
-    recompile=False,
-):
-    if recompile:
-        subprocess.run(["mvn", "clean", "package"], check=True)
-    gcm_command = [
-        "java",
-        "-jar",
-        jar_file,
-        "-i",
-        yaml_file,
-        "-o",
-        output_dir,
-        "-t",
-        str(gcm_threads),
-    ]
-    subprocess.run(
-        gcm_command,
-        check=True,
-    )  # TODO: write output to a logfile if needed
+def write_default_cmd(
+        simulation_dir: str,
+        model_type: str,
+        exe_file: str,
+        ):
+    output_dir = os.path.join(simulation_dir, "output")
+    if model_type == "gcm":
+        input_file = os.path.join(simulation_dir, f"input.yaml")
+        cmd = ["java", "-jar", exe_file, "-i", input_file, "-o", output_dir, "-t", "4"]
+    elif model_type == "ixa":
+        input_file = os.path.join(simulation_dir, f"input.json")
+        cmd = [f"./{exe_file}", "--config", f"./{input_file}", "--prefix", f"{output_dir}/"]
+    else:
+        raise ValueError(f"Unsupported model type: {model_type}. must be 'gcm' or 'ixa'")
 
-
-def run_ixa_command_line(ixa_file, json_file="./input.json"):
-    ixa_command = [f"./{ixa_file}", json_file]
-    print(ixa_command)
-    subprocess.run(
-        ixa_command,
-        check=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
-
+    return cmd
 
 def parameters_writer(params: dict, output_type: str = "YAML") -> str:
     """

--- a/abmwrappers/wrappers.py
+++ b/abmwrappers/wrappers.py
@@ -223,13 +223,14 @@ def experiments_writer(
         with open(full_params_path, "w") as f:
             f.write(full_params_json)
 
+
 def run_local_simulation(
-        simulation_dir, 
-        model_type: str, 
-        exe_file, 
-        cmd: list = None, 
-        recompile=False
-        ):
+    simulation_dir,
+    model_type: str,
+    exe_file,
+    cmd: list = None,
+    recompile=False,
+):
     if cmd is None:
         cmd = utils.write_default_cmd(simulation_dir, model_type, exe_file)
     utils.run_model_command_line(cmd, model_type, recompile)


### PR DESCRIPTION
## Overview
We need slightly more flexible control to pass additional arguments on a command basis (especially if writing over output from ixa). In general this doesn't solve the problem for arbitrary cases but should work for default experiments defined through a simulation bundle and for calling individual local runs in other files.

## Changes
The run command sequence had several `ifelse`s and no way to specify an arbitrary non-default `cmd` to run. Model type supply was also determined automatically but should be manual for agreement. Experiment sequence didn't pass model type to the subprocesses

