### PR TITLE
Nested parameter input handling

### DIFF
--- a/abmwrappers/utils.py
+++ b/abmwrappers/utils.py
@@ -15,6 +15,7 @@ from scipy.stats.qmc import Sobol
 # Global character sequence for flattening nested parameters
 FLATTENED_PARAM_CONNECTOR = ">>>"
 
+
 def run_gcm_command_line(
     jar_file,
     yaml_file="./input/config.yaml",
@@ -41,7 +42,7 @@ def run_gcm_command_line(
     )  # TODO: write output to a logfile if needed
 
 
-def flatten_dict(d, parent_key='', sep=FLATTENED_PARAM_CONNECTOR):
+def flatten_dict(d, parent_key="", sep=FLATTENED_PARAM_CONNECTOR):
     items = []
     for k, v in d.items():
         new_key = f"{parent_key}{sep}{k}" if parent_key else k
@@ -57,18 +58,20 @@ def unflatten_dict(flat_dict, sep=FLATTENED_PARAM_CONNECTOR):
     for key, value in flat_dict.items():
         parts = key.split(sep)
         current_level = result
-        
+
         for part in parts[:-1]:
             if part not in current_level:
-                current_level[part] = {} 
+                current_level[part] = {}
             current_level = current_level[part]
-        
+
         current_level[parts[-1]] = value
 
     return result
 
 
-def gcm_parameters_writer(params: dict, output_type: str = "YAML", unflatten: bool = True) -> str:
+def gcm_parameters_writer(
+    params: dict, output_type: str = "YAML", unflatten: bool = True
+) -> str:
     """
     Converts a dictionary of parameters to the specified output format.
 
@@ -82,7 +85,7 @@ def gcm_parameters_writer(params: dict, output_type: str = "YAML", unflatten: bo
 
     if unflatten:
         params = unflatten_dict(params)
-    
+
     if output_type == "YAML":
         params_output = yaml.dump(params)
     # Add more conditions for other output types as needed
@@ -93,7 +96,10 @@ def gcm_parameters_writer(params: dict, output_type: str = "YAML", unflatten: bo
 
 
 def combine_params_dicts(
-    baseline_dict: dict, new_dict: dict, scenario_key: str = "baseScenario", flatten: bool = False
+    baseline_dict: dict,
+    new_dict: dict,
+    scenario_key: str = "baseScenario",
+    flatten: bool = False,
 ) -> Tuple[dict, str]:
     """
     Combines two dictionaries by overwriting values in baseline_dict with values from new_dict. It also flattens any nested parameters using FLATTENED_PARAM_CONNECTOR.
@@ -172,7 +178,10 @@ def load_baseline_params(
 
             # Create baseline_params by updating default_params with baseline_params_input
             return combine_params_dicts(
-                default_params, baseline_params_input, scenario_key, flatten=True
+                default_params,
+                baseline_params_input,
+                scenario_key,
+                flatten=True,
             )
 
         except yaml.YAMLError as e:

--- a/abmwrappers/utils.py
+++ b/abmwrappers/utils.py
@@ -84,7 +84,7 @@ def gcm_parameters_writer(
     """
 
     if unflatten:
-        params = unflatten_dict(params)
+        params = {key: unflatten_dict(value) for key, value in params.items()}
 
     if output_type == "YAML":
         params_output = yaml.dump(params)

--- a/abmwrappers/utils.py
+++ b/abmwrappers/utils.py
@@ -68,7 +68,7 @@ def unflatten_dict(flat_dict, sep=FLATTENED_PARAM_CONNECTOR):
     return result
 
 
-def gcm_parameters_writer(params: dict, output_type: str = "YAML") -> str:
+def gcm_parameters_writer(params: dict, output_type: str = "YAML", unflatten: bool = True) -> str:
     """
     Converts a dictionary of parameters to the specified output format.
 
@@ -79,6 +79,9 @@ def gcm_parameters_writer(params: dict, output_type: str = "YAML") -> str:
     Returns:
         str: String representation of the parameters in the specified format.
     """
+
+    if unflatten:
+        params = unflatten_dict(params)
     
     if output_type == "YAML":
         params_output = yaml.dump(params)
@@ -90,7 +93,7 @@ def gcm_parameters_writer(params: dict, output_type: str = "YAML") -> str:
 
 
 def combine_params_dicts(
-    baseline_dict: dict, new_dict: dict, scenario_key: str = "baseScenario"
+    baseline_dict: dict, new_dict: dict, scenario_key: str = "baseScenario", flatten: bool = False
 ) -> Tuple[dict, str]:
     """
     Combines two dictionaries by overwriting values in baseline_dict with values from new_dict. It also flattens any nested parameters using FLATTENED_PARAM_CONNECTOR.
@@ -99,6 +102,7 @@ def combine_params_dicts(
         baseline_dict (dict): The baseline dictionary.
         new_dict (dict): The dictionary containing new values to be combined.
         scenario_key (str): any scenario key which the values fall under (will be preserved)
+        flatten (bool): whether to flatten nested parameters
 
     Returns:
         Tuple[dict, str]: A tuple containing the combined dictionary and a summary string.
@@ -122,11 +126,12 @@ def combine_params_dicts(
         f"Updated keys: {updated_keys}\nNot modified keys: {not_modified_keys}"
     )
 
-    # Flatten dictionary
-    temp_dict_flat = flatten_dict(temp_dict)
+    if flatten:
+        # Flatten dictionary
+        temp_dict = flatten_dict(temp_dict)
 
     # Re-introduce the scenario key
-    combined_dict = {scenario_key: temp_dict_flat}
+    combined_dict = {scenario_key: temp_dict}
 
     return combined_dict, result_string
 
@@ -167,7 +172,7 @@ def load_baseline_params(
 
             # Create baseline_params by updating default_params with baseline_params_input
             return combine_params_dicts(
-                default_params, baseline_params_input, scenario_key
+                default_params, baseline_params_input, scenario_key, flatten=True
             )
 
         except yaml.YAMLError as e:


### PR DESCRIPTION
## Overview
We need to sometimes specify parameters in a conveniently nested format but the current functionality doesn't allow for querying dictionaries with this structure when combining baseline parameters with inputs that are user-supplied or sampled from priors.

## Changes
Allows user to specify nested parameters, such as
```yaml
GammaDistribution:
  shape: 1.5
  scale: 1.0
```

to be read using the format `GammaDistribution>>>shape` and `GammaDistribution>>>scale`, which depend on the global variable separator `>>>` but can be modified by the user.

Replaces #10 , depends on #11