### PR TITLE
Pass max autoscale nodes to client pool

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,7 +1,6 @@
 name: pre-commit
 
 on:
-  workflow_dispatch:
   pull_request:
   push:
     branches: [main]
@@ -14,5 +13,6 @@ jobs:
     - uses: actions/setup-python@v5
     - uses: r-lib/actions/setup-r@v2
       with:
+        r-version: "4.4.0"
         use-public-rspm: true
     - uses: ./.github/actions/pre-commit

--- a/abmwrappers/utils.py
+++ b/abmwrappers/utils.py
@@ -513,6 +513,7 @@ def initialize_azure_client(
             client.set_pool_info(
                 mode=pool_mode,
                 dedicated_nodes=autoscale_nodes,
+                max_autoscale_nodes=autoscale_nodes,
                 cache_blobfuse=cache_blobfuse,
                 task_slots_per_node=task_slots_per_node,
             )


### PR DESCRIPTION
Previously pool info did not have access to autoscale nodes, so the default three was being used. This change should allow for autoscale jobs to have more than three nodes