### PR TITLE
Skip azure tasks with existing distances as non-default troubleshooting option

### DIFF
--- a/abmwrappers/experiment_class.py
+++ b/abmwrappers/experiment_class.py
@@ -585,6 +585,29 @@ class Experiment:
             df = pl.scan_parquet(path).collect()
         return df
 
+    def blob_directory_exists(self, src_path: str) -> bool:
+        """
+        Search for a directory wihtin a blob container. The blob container name should not be included in the directory path
+
+        Args:
+        src_path: String label for the directory within the blob to check for existence. Including the blob container name will raise an unimplemented error.
+        """
+        if self.blob_container_name in src_path:
+            raise NotImplementedError(
+                "The blob container name should not be included in the source directory path"
+            )
+        if self.azure_batch:
+            return utils.check_virtual_directory_existence(
+                self.storage_config,
+                self.cred,
+                self.blob_container_name,
+                src_path,
+            )
+        else:
+            raise ValueError(
+                "Cannot determine if blob directory exists unless azure batch is set to True."
+            )
+
     def store_products(
         self,
         sim_indices: list[int] | int,
@@ -1190,9 +1213,12 @@ class Experiment:
             )
         else:
             sim_bundle.results = index_df
+<<<<<<< HEAD
 
         if "distances" in products and distance_fn is not None:
             sim_bundle.calculate_distances(self.target_data, distance_fn)
+=======
+>>>>>>> 0a0abf9 (Reuse distances optionally during abc)
 
         if compress:
             self.store_products(

--- a/abmwrappers/experiment_class.py
+++ b/abmwrappers/experiment_class.py
@@ -1227,7 +1227,6 @@ class Experiment:
         if compress:
             self.store_products(
                 sim_indices=[simulation_index],
-                distance_fn=distance_fn,
                 products=products,
                 products_output_dir=products_output_dir,
             )

--- a/abmwrappers/experiment_class.py
+++ b/abmwrappers/experiment_class.py
@@ -1213,12 +1213,9 @@ class Experiment:
             )
         else:
             sim_bundle.results = index_df
-<<<<<<< HEAD
 
         if "distances" in products and distance_fn is not None:
             sim_bundle.calculate_distances(self.target_data, distance_fn)
-=======
->>>>>>> 0a0abf9 (Reuse distances optionally during abc)
 
         if compress:
             self.store_products(

--- a/abmwrappers/experiment_class.py
+++ b/abmwrappers/experiment_class.py
@@ -610,12 +610,19 @@ class Experiment:
 
     def store_products(
         self,
-        sim_indices: list[int] | int,
+        sim_indices: list[int] | pl.Series | int,
         products: list[str] | str | None = None,
         products_output_dir: str | None = None,
     ):
         if not isinstance(sim_indices, list):
-            sim_indices = [sim_indices]
+            if isinstance(sim_indices, pl.Series):
+                sim_indices = sim_indices.to_list()
+            elif isinstance(sim_indices, int):
+                sim_indices = [sim_indices]
+            else:
+                raise NotImplementedError(
+                    "Simulation indices must be specified using int, list[int], or pl.Series"
+                )
 
         if not isinstance(products, list):
             products = [products]

--- a/abmwrappers/wrappers.py
+++ b/abmwrappers/wrappers.py
@@ -404,9 +404,7 @@ def run_abcsmc(
                 products = ["distances"]
 
             if use_existing_distances:
-                distances_path = (
-                    f"{experiment.sub_experiment_name}/data/distances/"
-                )
+                distances_path = f"{experiment.data_path}/distances/"
                 if os.path.exists(distances_path):
                     stored_distances = experiment.parquet_from_path(
                         distances_path

--- a/abmwrappers/wrappers.py
+++ b/abmwrappers/wrappers.py
@@ -298,18 +298,22 @@ def run_abcsmc(
             distances_path = (
                 f"{experiment.sub_experiment_name}/data/distances/"
             )
-            if experiment.blob_directory_exists(distances_path):
-                stored_distances = experiment.parquet_from_path(
-                    distances_path, verbose=False
-                )
-                if experiment.verbose:
-                    print(
-                        f"""Re-using previously calculated distances.
-                        Found {stored_distances.height} values.
-                        These are not verified to match inputs.
-                        Please only use for re-running and extending same experiment."""
+            try:
+                if experiment.blob_directory_exists(distances_path):
+                    stored_distances = experiment.parquet_from_path(
+                        distances_path, verbose=False
                     )
-            else:
+                    if experiment.verbose:
+                        print(
+                            f"""Re-using previously calculated distances.
+                            Found {stored_distances.height} values.
+                            These are not verified to match inputs.
+                            Please only use for re-running and extending same experiment."""
+                        )
+                else:
+                    raise StopIteration
+
+            except StopIteration:
                 use_existing_distances = False
                 if experiment.verbose:
                     print(


### PR DESCRIPTION
Reuse previously calculated distances in the `run_abcsmc` function in `abmwrappers/wrappers.py`. This enhancement aims to improve efficiency when re-running or extending experiments by avoiding redundant computations but could lead to unexpected results if the experiment parameters change in such a way to alter previous simulations

### Changes
* Added a new parameter `use_existing_distances` to the `run_abcsmc` function, defaulting to `False`.
* Load distances from blob before submitting tasks, along with a warning message about ensuring input consistency.
* Added a conditional check to determine whether to run simulations based on the presence of precomputed distances in blob storage location. If distances exist for a given simulation index, the simulation is skipped.
* Replaced the `tasks_id_range` list with `task_ids` and updated the logic to calculate the task range using `min` and `max` functions.