### PR TITLE
Property getters for simulation history

### DIFF
--- a/abmwrappers/experiment_class.py
+++ b/abmwrappers/experiment_class.py
@@ -634,7 +634,7 @@ class Experiment:
                     pl.col("simulation") == simulation_index
                 ).write_parquet(inputs_data_part_path + "data.parquet")
 
-    def read_distances(self, input_dir: str = None, overwrite: bool = False):
+    def gather_distances(self, input_dir: str = None, overwrite: bool = False):
         """
         Read distances and simulation results into the simulation bundle history
         Currently yields OSError when called on a mounted blob container input directory
@@ -982,8 +982,32 @@ class Experiment:
                 simulation_index += 1
 
     # --------------------------------------------
-    # Simulation bundles and ABC SMC funcitons
+    # Simulation bundles and ABC SMC functions
     # --------------------------------------------
+
+    @property
+    def distances(self) -> pl.DataFrame:
+        dfs = [
+            bundle.distances.with_columns(pl.lit(step).alias("step"))
+            for step, bundle in self.simulation_bundles.items()
+        ]
+        return utils._vstack_dfs(dfs)
+
+    @property
+    def inputs(self) -> pl.DataFrame:
+        dfs = [
+            bundle.inputs.with_columns(pl.lit(step).alias("step"))
+            for step, bundle in self.simulation_bundles.items()
+        ]
+        return utils._vstack_dfs(dfs)
+
+    @property
+    def weights(self) -> pl.DataFrame:
+        dfs = [
+            bundle.weights.with_columns(pl.lit(step).alias("step"))
+            for step, bundle in self.simulation_bundles.items()
+        ]
+        return utils._vstack_dfs(dfs)
 
     def initialize_simbundle(
         self,

--- a/abmwrappers/wrappers.py
+++ b/abmwrappers/wrappers.py
@@ -176,7 +176,7 @@ def update_abcsmc_img(
     experiment = Experiment(img_file=experiment_file)
 
     # Load the distances
-    experiment.read_distances(input_dir=products_path, overwrite=True)
+    experiment.gather_distances(input_dir=products_path, overwrite=True)
     experiment.resample()
 
     # Save the updated experiment
@@ -361,7 +361,7 @@ def run_abcsmc(
             # Products_from_index currently adds only one distance at a time
             # We recreate the data loss of update_abcsmc_img here using `del`
             del experiment.simulation_bundles[step].distances
-            experiment.read_distances(experiment.data_path)
+            experiment.gather_distances(experiment.data_path)
             experiment.resample(perturbation_kernels)
 
         if save:

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -218,7 +218,7 @@ Stores processed simulation outputs (e.g., distances and simulations) as Parquet
 
 ---
 
-### Method: `read_distances`
+### Method: `gather_distances`
 
 #### Description
 Reads distance data from storage and integrates it into the simulation bundle's history. It validates the presence of distance data and ensures that the current step does not already contain distances before updating the bundle.
@@ -389,7 +389,7 @@ A simple exmaple of manipulating Experiments using save-restore is the
 experiment = Experiment(img_file=experiment_file)
 
 # Load the distances
-experiment.read_distances(input_dir=products_path)
+experiment.gather_distances(input_dir=products_path)
 experiment.resample()
 
 # Save the updated experiment

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -109,3 +109,65 @@ def test_get_default_param():
         )
         == 1.0
     )
+
+
+def test_collect_history():
+    experiment = Experiment(
+        experiments_directory="tests",
+        config_file="tests/input/test_config.yaml",
+    )
+
+    for step in range(3):
+        bundle = SimulationBundle(
+            inputs=pl.DataFrame(),
+            step_number=step,
+            baseline_params={
+                "baseScenario": {
+                    "my_distribution": {"norm": {"mean": 0.0, "sd": 1.0}},
+                    "my_scalar": 3.0,
+                }
+            },
+        )
+        bundle.distances = pl.DataFrame(
+            {
+                "simulation": [i + 2 * step for i in range(2)],
+                "distance": [0.0] * 2,
+            }
+        )
+        bundle.weights = pl.DataFrame(
+            {
+                "simulation": [i + 2 * step for i in range(2)],
+                "weights": [0.1] * 2,
+            }
+        )
+        bundle.inputs = pl.DataFrame(
+            {
+                "simulation": [i + 2 * step for i in range(2)],
+                "value": [0.2] * 2,
+            }
+        )
+
+        experiment.simulation_bundles.update({step: bundle})
+
+    all_data = pl.DataFrame(
+        {"simulation": [0, 1, 2, 3, 4, 5], "step": [0, 0, 1, 1, 2, 2]}
+    )
+
+    assert_frame_equal(
+        experiment.distances,
+        all_data.with_columns(pl.lit(0.0).alias("distance")),
+        check_dtypes=False,
+        check_column_order=False,
+    )
+    assert_frame_equal(
+        experiment.weights,
+        all_data.with_columns(pl.lit(0.1).alias("weights")),
+        check_dtypes=False,
+        check_column_order=False,
+    )
+    assert_frame_equal(
+        experiment.inputs,
+        all_data.with_columns(pl.lit(0.2).alias("value")),
+        check_dtypes=False,
+        check_column_order=False,
+    )


### PR DESCRIPTION
This pull request introduces improvements to the handling and aggregation of simulation outputs in the experiment workflow, focusing on data collection and API clarity.

**Changes**
* Renamed the `read_distances` method in `Experiment` to `gather_distances` for better clarity and updated all usages accordingly in both code and documentation.
* Added three new properties to the `Experiment` class: `distances`, `inputs`, and `weights`, each returning a vertically stacked `DataFrame` of the respective data across all simulation steps.
* Added the `test_collect_history` test to verify that the new aggregation properties correctly combine data from multiple simulation steps.